### PR TITLE
SSO and binary file support to master (#48)

### DIFF
--- a/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
+++ b/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
@@ -21,6 +21,7 @@ import org.zowe.api.common.errors.ApiError;
 import org.zowe.api.common.exceptions.ZoweApiRestException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 public abstract class AbstractHttpIntegrationTest {
 

--- a/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/InvalidAuthTokenException.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/InvalidAuthTokenException.java
@@ -11,7 +11,7 @@ package org.zowe.api.common.exceptions;
 
 import org.springframework.http.HttpStatus;
 
-public class InvalidAuthTokenException extends ZoweApiRestException{
+public class InvalidAuthTokenException extends ZoweApiRestException {
 
     /**
      * 

--- a/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/NoAuthTokenException.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/NoAuthTokenException.java
@@ -11,6 +11,7 @@ package org.zowe.api.common.exceptions;
 
 import org.springframework.http.HttpStatus;
 
+
 public class NoAuthTokenException extends ZoweApiRestException{
 
     /**

--- a/explorer-api-common/src/main/java/org/zowe/api/common/utils/ResponseCache.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/utils/ResponseCache.java
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Copyright IBM Corporation 2018, 2019
+ * Copyright IBM Corporation 2018, 2020
  */
 package org.zowe.api.common.utils;
 
@@ -19,6 +19,8 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.util.EntityUtils;
+import org.springframework.http.MediaType;
+import org.springframework.util.Base64Utils;
 
 import java.io.IOException;
 
@@ -36,7 +38,13 @@ public class ResponseCache {
         }
         this.entity = response.getEntity();
         if (entity != null) {
-            this.entityString = EntityUtils.toString(entity, "UTF-8");
+            if (isOctetStream()) {
+                // binary data to base64 string
+                byte[] entityContent = EntityUtils.toByteArray(entity);
+                this.entityString = Base64Utils.encodeToString(entityContent);
+            } else {
+                this.entityString = EntityUtils.toString(entity, "UTF-8");
+            }
         }
     }
 
@@ -66,6 +74,10 @@ public class ResponseCache {
 
     public ContentType getContentType() {
         return ContentType.get(entity);
+    }
+
+    private boolean isOctetStream() {
+        return this.getContentType().getMimeType().equals(MediaType.APPLICATION_OCTET_STREAM_VALUE);
     }
 
     // TODO - do we need to cache this?

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ artifactoryPublishingMavenRepo=https://zowe.jfrog.io/zowe/libs-release-local
 artifactoryPublishingMavenSnapshotRepo=https://zowe.jfrog.io/zowe/libs-snapshot-local
 
 # Artifacts version
-version=1.0.1
+version=1.0.2
 
 defaultSpringBootVersion=2.0.2.RELEASE
 defaultSpringBootCloudVersion=2.0.0.RELEASE


### PR DESCRIPTION
* SSO implementation - Support for use of apimlAuthenticationToken (#43)

* extract apimlAuthorizationToken and pass through for all auth

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* fix linting errors

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* fix boolean check

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* add back ApiControllerTest and fix exception construction

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* logon to api gateway

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* switch to constructor for intialising logon

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Get token when provided in auth header too

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* ensure cookie header is not null before tring to get token from it

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* debug getting apimlauthtoken

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* check for null auth header before checking if empty

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* add getter for gateway port

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Cleanup unused debug statements

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Remove logout matcher and revoke unneccessary copyright update

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Missed copyright update

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* version bump

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Set fail build to false (#46)

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* zosmf return octet stream convert to b64 encoding (#45)

* zosmf return octet stream convert to b64 encoding

Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

* Resync staging with master (#49)

* SSO implementation - Support for use of apimlAuthenticationToken (#43) (#44)

* SSO implementation - Support for use of apimlAuthenticationToken (#43)

* extract apimlAuthorizationToken and pass through for all auth

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* fix linting errors

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* fix boolean check

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* add back ApiControllerTest and fix exception construction

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* logon to api gateway

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* switch to constructor for intialising logon

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Get token when provided in auth header too

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* ensure cookie header is not null before tring to get token from it

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* debug getting apimlauthtoken

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* check for null auth header before checking if empty

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* add getter for gateway port

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Cleanup unused debug statements

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Remove logout matcher and revoke unneccessary copyright update

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Missed copyright update

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* version bump

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

* Set fail build to false (#46)

Signed-off-by: Jordan Cain <jordan.cain1@uk.ibm.com>

Co-authored-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

* 1.0.1

Signed-off-by: zowe-robot <zowe.robot@gmail.com>

Co-authored-by: Jordan Cain <30590180+jordanCain@users.noreply.github.com>
Co-authored-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>
Co-authored-by: zowe-robot <zowe.robot@gmail.com>

Co-authored-by: Jordan Cain <30590180+jordanCain@users.noreply.github.com>
Co-authored-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>
Co-authored-by: zowe-robot <zowe.robot@gmail.com>