### PR TITLE
add separate gateway port, and some style fixes

### DIFF
--- a/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
+++ b/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
@@ -30,6 +30,8 @@ public abstract class AbstractHttpIntegrationTest {
     private final static String SERVER_HOST = System.getProperty("server.host");
     private final static String SERVER_PORT = System.getProperty("server.port");
 
+    // these are optional, if not provided, we use server host and port params
+    // it helps use separate gateway host & port for authentication during testing
     private final static String GATEWAY_HOST = System.getProperty("gateway.host");
     private final static String GATEWAY_PORT = System.getProperty("gateway.port");
 
@@ -63,6 +65,7 @@ public abstract class AbstractHttpIntegrationTest {
         return new Header("Authorization", "Bearer " + response.getCookie("apimlAuthenticationToken"));
     }
 
+    // use provided gateway host and port first when provided 
     private static String getGatewayHost() {
         if (GATEWAY_HOST != null) {
             return GATEWAY_HOST;

--- a/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
+++ b/explorer-api-common-test/src/main/java/org/zowe/api/common/test/AbstractHttpIntegrationTest.java
@@ -14,15 +14,13 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 
-import static org.junit.Assert.assertEquals;
-
-import java.nio.charset.StandardCharsets;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
 import org.junit.BeforeClass;
 import org.zowe.api.common.errors.ApiError;
 import org.zowe.api.common.exceptions.ZoweApiRestException;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -31,6 +29,9 @@ public abstract class AbstractHttpIntegrationTest {
 
     private final static String SERVER_HOST = System.getProperty("server.host");
     private final static String SERVER_PORT = System.getProperty("server.port");
+
+    private final static String GATEWAY_HOST = System.getProperty("gateway.host");
+    private final static String GATEWAY_PORT = System.getProperty("gateway.port");
 
     protected final static String BASE_URL = getBaseUrl();
 
@@ -57,9 +58,23 @@ public abstract class AbstractHttpIntegrationTest {
     private static Header getJWTAuthHeader() {
         Response response = RestAssured.given().contentType("application/json")
                 .body("{\"username\":\"" + USER + "\",\"password\":\"" + PASSWORD + "\"}")
-                .when().post("https://" + SERVER_HOST + ":" + SERVER_PORT + "/api/v1/gateway/auth/login");
+                .when().post("https://" + getGatewayHost() + ":" + getGatewayPort() + "/api/v1/gateway/auth/login");
         assertEquals(response.getStatusCode(), HttpStatus.SC_NO_CONTENT);
         return new Header("Authorization", "Bearer " + response.getCookie("apimlAuthenticationToken"));
+    }
+
+    private static String getGatewayHost() {
+        if (GATEWAY_HOST != null) {
+            return GATEWAY_HOST;
+        }
+        return SERVER_HOST;
+    }
+
+    private static String getGatewayPort() {
+        if (GATEWAY_PORT != null) {
+            return GATEWAY_PORT;
+        }
+        return SERVER_PORT;
     }
     
     private static Header getBasicAuthHeader() {

--- a/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ConnectionProperties.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ConnectionProperties.java
@@ -9,11 +9,11 @@
  */
 package org.zowe.api.common.connectors.zosmf;
 
+import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import lombok.Data;
 
 @Data
 @Configuration

--- a/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnector.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnector.java
@@ -9,19 +9,7 @@
  */
 package org.zowe.api.common.connectors.zosmf;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -30,11 +18,22 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.zowe.api.common.connectors.zosmf.exceptions.ZosmfConnectionException;
 
-import lombok.extern.slf4j.Slf4j;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 
 @Slf4j
 public abstract class ZosmfConnector {
-    
     private final String host;
     private final int port;
 
@@ -42,11 +41,9 @@ public abstract class ZosmfConnector {
         host = properties.getIpAddress();
         port = properties.getHttpsPort();
     }
-    
     public URI getFullUrl(String relativePath) throws URISyntaxException {
         return getFullUrl(relativePath, null);
     }
-    
     public URI getFullUrl(String relativePath, String query) throws URISyntaxException {
         try {
             return new URI("https", null, host, port, "/api/v1/zosmf/" + relativePath, query, null);
@@ -55,14 +52,14 @@ public abstract class ZosmfConnector {
             throw e;
         }
     }
-    
+
     public abstract Header getAuthHeader();
     
     public HttpResponse executeRequest(RequestBuilder requestBuilder) throws IOException {
         requestBuilder.setHeader(getAuthHeader());
         requestBuilder.setHeader("X-CSRF-ZOSMF-HEADER", "");
         requestBuilder.setHeader("X-IBM-Response-Timeout", "600");
-        
+
         HttpClient client;
         try {
             client = createIgnoreSSLClient();
@@ -75,7 +72,7 @@ public abstract class ZosmfConnector {
 
     public static HttpClient createIgnoreSSLClient() throws KeyManagementException, NoSuchAlgorithmException {
         SSLContext sslcontext = SSLContext.getInstance("TLS");
-        sslcontext.init(null, new TrustManager[]{new X509TrustManager() {
+        sslcontext.init(null, new TrustManager[] { new X509TrustManager() {
             @Override
             public void checkClientTrusted(X509Certificate[] arg0, String arg1) {
             }
@@ -99,5 +96,5 @@ public abstract class ZosmfConnector {
 
         }).build();
     }
-    
+
 }

--- a/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnectorJWTAuth.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnectorJWTAuth.java
@@ -9,23 +9,23 @@
  */
 package org.zowe.api.common.connectors.zosmf;
 
-import java.util.Arrays;
-import java.util.Optional;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.zowe.api.common.exceptions.NoAuthTokenException;
 
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Optional;
+
 @Service
 public class ZosmfConnectorJWTAuth extends ZosmfConnector {
-    
+
     @Autowired
     private HttpServletRequest request;
-    
+
     @Autowired
     public ZosmfConnectorJWTAuth(ConnectionProperties properties) {
         super(properties);
@@ -36,14 +36,15 @@ public class ZosmfConnectorJWTAuth extends ZosmfConnector {
         String cookieHeader = request.getHeader("cookie");
         if (cookieHeader != null && !cookieHeader.isEmpty()) {
             String[] cookies = cookieHeader.split(";");
-            Optional<String> authTokenCookie = Arrays.stream(cookies).filter(c -> c.contains("apimlAuthenticationToken")).findFirst();
-            if(authTokenCookie.isPresent()) {
+            Optional<String> authTokenCookie = Arrays.stream(cookies)
+                    .filter(c -> c.contains("apimlAuthenticationToken")).findFirst();
+            if (authTokenCookie.isPresent()) {
                 return new BasicHeader("Authorization", "Bearer " + authTokenCookie.get().split("=")[1]);
             }
         } else {
-            // If user is passing jwt in Authorization header 
+            // If user is passing jwt in Authorization header
             String header = request.getHeader("authorization");
-            if(header != null && !header.isEmpty()) {
+            if (header != null && !header.isEmpty()) {
                 return new BasicHeader("Authorization", header);
             }
         }

--- a/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnectorLtpaAuth.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/connectors/zosmf/ZosmfConnectorLtpaAuth.java
@@ -9,19 +9,6 @@
  */
 package org.zowe.api.common.connectors.zosmf;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -43,6 +30,19 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.zowe.api.common.security.CustomUser;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 
 @Service
 public class ZosmfConnectorLtpaAuth extends ZosmfConnector {

--- a/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/NoAuthTokenException.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/exceptions/NoAuthTokenException.java
@@ -11,8 +11,7 @@ package org.zowe.api.common.exceptions;
 
 import org.springframework.http.HttpStatus;
 
-
-public class NoAuthTokenException extends ZoweApiRestException{
+public class NoAuthTokenException extends ZoweApiRestException {
 
     /**
      * 

--- a/explorer-api-common/src/main/java/org/zowe/api/common/zosmf/services/AbstractZosmfRequestRunner.java
+++ b/explorer-api-common/src/main/java/org/zowe/api/common/zosmf/services/AbstractZosmfRequestRunner.java
@@ -9,10 +9,11 @@
  */
 package org.zowe.api.common.zosmf.services;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.stream.IntStream;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -26,11 +27,10 @@ import org.zowe.api.common.exceptions.ServerErrorException;
 import org.zowe.api.common.exceptions.ZoweApiRestException;
 import org.zowe.api.common.utils.ResponseCache;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.IntStream;
 
 @Slf4j
 public abstract class AbstractZosmfRequestRunner<T> {


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

Providing option during development to provide separate gateway port param, to retrieve JWT token
AbstractHttpIntegrationTest.java

Others are style fixes so, 
./gradlew build locally